### PR TITLE
feat(build): create release pipeline for `runtime-metamodel`

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,18 @@
+# This file determines how the auto-generated Release Notes in GitHub releases are structured.
+
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: New Features & Improvements
+      labels:
+        - "*"
+    - title: Documentation
+      labels:
+        - documentation

--- a/.github/workflows/release-runtime-metamodel.yml
+++ b/.github/workflows/release-runtime-metamodel.yml
@@ -1,0 +1,77 @@
+name: Create Runtime Metamodel Release
+on:
+  workflow_dispatch:
+    inputs:
+      metamodel_version:
+        description: 'Version string that is used for publishing (e.g. "1.0.0", NOT "v1.0.0"). Appending -SNAPSHOT will create a snapshot release.'
+        required: true
+        type: string
+
+
+env:
+  METAMODEL_VERSION: ${{ github.event.inputs.metamodel_version || inputs.metamodel_version }}
+
+jobs:
+  Prepare-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # create tag on the current branch using GitHub's own API
+      - name: Create tag on current branch (main)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ env.METAMODEL_VERSION }}',
+              sha: context.sha
+            })
+
+      # create merge commit main -> releases encoding the version in the commit message
+      - name: Merge main -> releases
+        uses: everlytic/branch-merge@1.1.4
+        with:
+          github_token: ${{ github.token }}
+          source_ref: ${{ github.ref }}
+          target_branch: 'releases'
+          commit_message_template: 'Merge commit for release of version v${{ env.METAMODEL_VERSION }}'
+
+      # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
+      # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.
+      # There is no way to cancel the process on Jenkins from withing GitHub.
+      - name: Trigger Release on EF Jenkins
+        uses: toptal/jenkins-job-trigger-action@master
+        with:
+          jenkins_url: "https://ci.eclipse.org/dataspaceconnector/"
+          jenkins_user: ${{ secrets.EF_JENKINS_USER }}
+          jenkins_token: ${{ secrets.EF_JENKINS_TOKEN }}
+          job_name: "Runtime-Metamodel-Autobuild-Release"
+          job_params: |
+            {
+              "VERSION": "${{ env.METAMODEL_VERSION }}"
+            }
+          job_timeout: "3600" # Default 30 sec. (optional)
+    outputs:
+      metamodel-version: ${{ env.METAMODEL_VERSION }}
+
+  Github-Release:
+    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.metamodel-version, '-SNAPSHOT') }}
+    needs:
+      - Prepare-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: "v${{ env.METAMODEL_VERSION }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          removeArtifacts: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 assertj=3.23.1
 jupiterVersion=5.9.0
 groupId=org.eclipse.dataspaceconnector
-projectVersion=0.0.1
+defaultVersion=0.0.1-SNAPSHOT
 jacksonVersion=2.13.3
 jetBrainsAnnotationsVersion=15.0

--- a/runtime-metamodel/build.gradle.kts
+++ b/runtime-metamodel/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 val jupiterVersion: String by project


### PR DESCRIPTION
## What this PR changes/adds

This PR adds two things:
1. a release workflow (identical to the main EDC repo)
2. a bit of logic for the build to be able to set the version on the CLI using the `-Pversion=...` parameter

## Why it does that

To be able to easily create release and `SNAPSHOT` versions

## Further notes

no new code has been implemented, I merely copied the logic from the EDC repo

## Linked Issue(s)

Closes #2 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
