### PR TITLE
fix: use correct urls, apply group and version to all projects

### DIFF
--- a/autodoc/build.gradle.kts
+++ b/autodoc/build.gradle.kts
@@ -53,7 +53,7 @@ tasks.test {
 pluginBundle {
     website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
     vcsUrl = "http://github.com/eclipse-dataspaceconnector/"
-    group = group
+    group = groupId
     version = version
     tags = listOf("build", "documentation", "generated", "autodoc")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,13 +16,20 @@ val jupiterVersion: String by project
 val assertj: String by project
 val mockitoVersion: String by project
 
+// values needed for publishing
+val pluginsWebsiteUrl: String by project
+val pluginsDeveloperId: String by project
+val pluginsDeveloperName: String by project
+val pluginsDeveloperEmail: String by project
+val pluginsScmConnection: String by project
+val pluginsScmUrl: String by project
 
 var actualVersion: String = (project.findProperty("version") ?: defaultVersion) as String
 if (actualVersion == "unspecified") {
     actualVersion = defaultVersion
 }
 
-subprojects {
+allprojects {
     apply(plugin = "checkstyle")
     version = actualVersion
     group = groupId
@@ -96,6 +103,37 @@ subprojects {
         }
     }
 
+    afterEvaluate {
+        publishing {
+            publications.forEach { i ->
+                val mp = (i as MavenPublication)
+                mp.pom {
+                    name.set(project.name)
+                    description.set("edc :: ${project.name}")
+                    url.set(pluginsWebsiteUrl)
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                        developers {
+                            developer {
+                                id.set(pluginsDeveloperId)
+                                name.set(pluginsDeveloperName)
+                                email.set(pluginsDeveloperEmail)
+                            }
+                        }
+                        scm {
+                            connection.set(pluginsScmConnection)
+                            url.set(pluginsScmUrl)
+                        }
+                    }
+                }
+//                println("\n${mp.groupId}:${mp.artifactId}:${mp.version}")
+            }
+        }
+    }
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,10 @@ groupId=org.eclipse.dataspaceconnector
 defaultVersion=0.0.1-SNAPSHOT
 jacksonVersion=2.13.3
 jetBrainsAnnotationsVersion=15.0
+# used for publishing artifacts and plugins
+pluginsDeveloperId=mspiekermann
+pluginsDeveloperName=Markus Spiekermann
+pluginsDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
+pluginsScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/GradlePlugins.git
+pluginsWebsiteUrl=https://github.com/eclipse-dataspaceconnector/GradlePlugins.git
+pluginsScmUrl=https://github.com/eclipse-dataspaceconnector/GradlePlugins.git


### PR DESCRIPTION
## What this PR changes/adds

Corrects some errors regarding the build file and the deployment urls:
- `groupId` and `version` is now applied to `allprojects` instead of only `subprojects`. this caused failures when initializing the staging repo.
- deployment urls were switched.

## Why it does that

enable snapshot and release builds

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)



## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
