### PR TITLE
fix: type in processor output path

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/AutodocPlugin.java
@@ -41,7 +41,8 @@ public class AutodocPlugin implements Plugin<Project> {
 
         // adds the annotation processor dependency
         project.getGradle().addListener(new AutodocDependencyInjector(project, format("%s:%s:", GROUP_NAME, PROCESSOR_ARTIFACT_NAME),
-                createVersionProvider(project), getOutputDirectoryProvider(project)));
+                createVersionProvider(project),
+                getOutputDirectoryProvider(project)));
 
         // registers a "named" task, that does nothing, except depend on the compileTask, which then runs the annotation processor
         project.getTasks().register("autodoc", t -> t.dependsOn("compileJava"));

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/EdcModuleProcessor.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/EdcModuleProcessor.java
@@ -67,7 +67,7 @@ import static javax.tools.Diagnostic.Kind.NOTE;
 public class EdcModuleProcessor extends AbstractProcessor {
     public static final String VERSION = "edc.version";
     public static final String ID = "edc.id";
-    public static final String EDC_OUTPUTDIR_OVERRIDE = "edc.outputdir";
+    public static final String EDC_OUTPUTDIR_OVERRIDE = "edc.outputDir";
     private static final String MANIFEST_NAME = "edc.json";
     private final ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes a small type in the processor's output path override 

## Why it does that

Puts the `edc.json` in the expected directory 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
