### PR TITLE
feat: add check-module-names plugin

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
@@ -133,7 +133,7 @@ abstract class EdcModuleProcessorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of("-Aedc.version=1.2.3", "-Aedc.id=someid", "-Aedc.outputDir=some/dir"),
+                    Arguments.of("-Aedc.version=1.2.3", "-Aedc.id=someid", "-Aedc.outputDir=build/some/dir"),
                     Arguments.of("-Aedc.version=1.2.3", "-Aedc.id=someid", null),
                     Arguments.of("-Aedc.version=1.2.3", "-Aedc.id=someid", "-Aedc.outputDir=")
             );

--- a/plugins/module-names/module-names-plugin/README.md
+++ b/plugins/module-names/module-names-plugin/README.md
@@ -1,0 +1,2 @@
+This module contains a gradle plugin that verifies that there are no two modules with the same name in a multi-module
+gradle project as this may cause problems during the build.

--- a/plugins/module-names/module-names-plugin/build.gradle.kts
+++ b/plugins/module-names/module-names-plugin/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-gradle-plugin`
+    id("org.gradle.crypto.checksum") version "1.4.0"
+}
+
+val jupiterVersion: String by project
+val assertj: String by project
+val groupId: String by project
+
+gradlePlugin {
+    // Define the plugin
+    plugins {
+        create("module-names") {
+            displayName = "module-names"
+            description =
+                "Plugin to verify that a project has no duplicate submodules (by name)"
+            id = "${groupId}.module-names"
+            implementationClass = "org.eclipse.dataspaceconnector.plugins.modulenames.ModuleNamesPlugin"
+        }
+    }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "verification")
+}

--- a/plugins/module-names/module-names-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/modulenames/CheckModuleNamesAction.java
+++ b/plugins/module-names/module-names-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/modulenames/CheckModuleNamesAction.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.plugins.modulenames;
+
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+
+public class CheckModuleNamesAction implements Action<Project> {
+
+    private final Predicate<String> isSampleModule = displayName -> displayName.contains(":samples:");
+    private final Predicate<String> isSystemTestModule = displayName -> displayName.contains(":system-tests:");
+    private final Predicate<String> excludeSamplesAndSystemTests = isSampleModule.or(isSystemTestModule).negate();
+    private final Function<String, String> projectName = it -> {
+        var split = it.replace("project '", "").replace("'", "").split(":");
+        return split[split.length - 1];
+    };
+
+    public CheckModuleNamesAction() {
+    }
+
+    @Override
+    public void execute(Project project) {
+        var subprojects = project.getSubprojects().stream()
+                .filter(it -> it.getBuildFile().exists())
+                .map(Project::getDisplayName)
+                .filter(excludeSamplesAndSystemTests)
+                .collect(groupingBy(projectName));
+
+        var duplicatedSubprojects = subprojects.entrySet().stream()
+                .filter(it -> it.getValue().size() > 1)
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (!duplicatedSubprojects.isEmpty()) {
+            var message = duplicatedSubprojects.entrySet().stream()
+                    .map(it -> it.getKey() + ":\n" + it.getValue().stream().collect(joining("\n\t", "\t", "")))
+                    .collect(joining("\n"));
+
+            throw new GradleException("Duplicate module names found: \n" + message);
+        }
+    }
+}

--- a/plugins/module-names/module-names-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/modulenames/ModuleNamesPlugin.java
+++ b/plugins/module-names/module-names-plugin/src/main/java/org/eclipse/dataspaceconnector/plugins/modulenames/ModuleNamesPlugin.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.plugins.modulenames;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Custom grade plugin to avoid module name duplications.
+ * Checks between modules with a gradle build file that their names are unique in the whole project.
+ * `samples` and `system-tests` modules are excluded.
+ * <p>
+ * Ref: <a href="https://github.com/gradle/gradle/issues/847">Github Issue</a>
+ */
+public class ModuleNamesPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+
+        project.afterEvaluate(new CheckModuleNamesAction());
+    }
+
+}

--- a/plugins/module-names/module-names-plugin/src/test/java/org/eclipse/dataspaceconnector/plugins/modulenames/ModuleNamesPluginTest.java
+++ b/plugins/module-names/module-names-plugin/src/test/java/org/eclipse/dataspaceconnector/plugins/modulenames/ModuleNamesPluginTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.plugins.modulenames;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.ProjectConfigurationException;
+import org.gradle.api.internal.project.DefaultProject;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchException;
+
+class ModuleNamesPluginTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void verifyFailsOnDuplicatedModule() throws IOException {
+        // Create a test project and apply the plugin
+        Project project = ProjectBuilder.builder().build();
+
+        project.getPlugins().apply(ModuleNamesPlugin.class);
+
+        var sp1 = createProjectDirectory(project, "subp1");
+        var sp2 = createProjectDirectory(project, "subp2");
+
+        // two sub-sub modules have the same name -> violation
+        createProjectDirectory(sp1, "subsub");
+        createProjectDirectory(sp2, "subsub");
+
+        var ex = catchException(() -> ((DefaultProject) project).evaluate());
+        assertThat(ex)
+                .isInstanceOf(ProjectConfigurationException.class)
+                .hasMessageStartingWith("A problem occurred configuring root project 'test'.")
+                .hasRootCauseInstanceOf(GradleException.class);
+        assertThat(ex.getCause())
+                .hasMessageContaining("Duplicate module names found");
+
+    }
+
+    @Test
+    void verifySucceedsWhenUniqueModuleNames() throws IOException {
+        // Create a test project and apply the plugin
+        Project project = ProjectBuilder.builder().build();
+
+        project.getPlugins().apply(ModuleNamesPlugin.class);
+
+        var sp1 = createProjectDirectory(project, "subp1");
+        var sp2 = createProjectDirectory(project, "subp2");
+
+        // two sub-sub modules have the same name -> violation
+        createProjectDirectory(sp1, "subsubX");
+        createProjectDirectory(sp2, "subsubY");
+
+        assertThatNoException().isThrownBy(() -> ((DefaultProject) project).evaluate());
+
+    }
+
+    private Project createProjectDirectory(Project parent, String name) throws IOException {
+        var buildDir = new File(String.format("./build/projects/%s/", UUID.randomUUID()));
+        assertThat(buildDir.mkdirs()).isTrue();
+
+        var buildFile = new File(buildDir, "build.gradle");
+        assertThat(buildFile.createNewFile()).isTrue();
+        return ProjectBuilder.builder().withParent(parent).withName(name).withProjectDir(buildDir).build();
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "edcPlugins"
 
+include("plugins:module-names:module-names-plugin")
 include("plugins:autodoc:autodoc-plugin")
 include("plugins:autodoc:autodoc-processor")
 include("runtime-metamodel")


### PR DESCRIPTION
## What this PR changes/adds

The `ModuleNamesPlugin` from the EDC's `buildSrc` directory was moved to this repo and is accessible via the `org.eclipse.dataspaceconnector.module-names` plugin (same as before).


## Why it does that

Moves all build sources out of the EDC repo to separate concerns.

## Further notes

- test was added to verify the action
- once this PR is merged, and the plugin is available from the snapshot repo, it should get removed from the EDC code base.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
