### PR TITLE
refactor: deprecate EdcSetting, add Setting

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/dataspaceconnector/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Requires;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Spi;
 import org.eclipse.dataspaceconnector.runtime.metamodel.domain.Service;
 
@@ -91,13 +92,14 @@ public class ModuleIntrospector {
      */
     public Set<Element> getExtensionElements(RoundEnvironment environment) {
         var extensionClasses = environment.getElementsAnnotatedWith(Extension.class);
-        var settingsSymbols = environment.getElementsAnnotatedWith(EdcSetting.class);
+        var settingsSymbolsDeprecated = environment.getElementsAnnotatedWith(EdcSetting.class);
+        var settingsSymbols = environment.getElementsAnnotatedWith(Setting.class);
         var injectSymbols = environment.getElementsAnnotatedWith(Inject.class);
         var providerSymbols = environment.getElementsAnnotatedWith(Provider.class);
         var providesClasses = environment.getElementsAnnotatedWith(Provides.class);
         var requiresClasses = environment.getElementsAnnotatedWith(Requires.class);
 
-        var symbols = settingsSymbols.stream();
+        var symbols = Stream.concat(settingsSymbols.stream(), settingsSymbolsDeprecated.stream());
         symbols = Stream.concat(symbols, injectSymbols.stream());
         symbols = Stream.concat(symbols, providerSymbols.stream());
 

--- a/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/EdcSettingContext.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/EdcSettingContext.java
@@ -22,10 +22,13 @@ import java.lang.annotation.Target;
 
 /**
  * Defines a context for setting keys.
+ *
+ * @deprecated please use {@link SettingContext}
  */
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Deprecated
 public @interface EdcSettingContext {
     String value();
 }

--- a/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/Setting.java
@@ -22,14 +22,11 @@ import java.lang.annotation.Target;
 
 /**
  * Denotes a runtime configuration setting.
- *
- * @deprecated Please use {@link Setting}
  */
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Deprecated
-public @interface EdcSetting {
+public @interface Setting {
 
     /**
      * The setting description.

--- a/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/SettingContext.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/dataspaceconnector/runtime/metamodel/annotation/SettingContext.java
@@ -21,30 +21,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Denotes a runtime configuration setting.
- *
- * @deprecated Please use {@link Setting}
+ * Defines a context for setting keys.
  */
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Deprecated
-public @interface EdcSetting {
-
-    /**
-     * The setting description.
-     */
-    String value() default "";
-
-    String type() default "string";
-
-    long min() default Long.MIN_VALUE;
-
-    long max() default Long.MAX_VALUE;
-
-    /**
-     * Returns true if the setting is required.
-     */
-    boolean required() default false;
-
+public @interface SettingContext {
+    String value();
 }


### PR DESCRIPTION
## What this PR changes/adds

Deprecates the `@EdcSetting` and `@EdcSettingContext` annotations, and introduces a new `@Setting` and `@SettingContext` annotations, both of which are exact copies of the old thing.

## Why it does that

To keep consistent with the naming of all other metamodel annotations.

## Further notes

We need to do the deprecation and removing in two separate steps, otherwise there could be a time where builds in downstream projects fail, until the make the switch as well.

## Linked Issue(s)

Closes #19 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
