### PR TITLE
perf: selectively apply plugins, add some perf options

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/EdcBuildBasePlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/EdcBuildBasePlugin.java
@@ -37,12 +37,8 @@ import org.gradle.testing.jacoco.plugins.JacocoPlugin;
 public class EdcBuildBasePlugin implements Plugin<Project> {
     private static void defineCapabilities(Project target) {
 
-        target.getPlugins().apply(ChecksumPlugin.class);
-        target.getPlugins().apply(DependencyAnalysisPlugin.class);
-
         target.getPlugins().apply(JavaLibraryPlugin.class);
         target.getPlugins().apply(JacocoPlugin.class);
-        target.getPlugins().apply(ModuleNamesPlugin.class);
         target.getPlugins().apply(AutodocPlugin.class);
         target.getPlugins().apply(CheckstylePlugin.class);
         target.getPlugins().apply(MavenPublishPlugin.class);
@@ -51,8 +47,11 @@ public class EdcBuildBasePlugin implements Plugin<Project> {
 
         // The nexus publish plugin MUST be applied to the root project only, it'll throw an exception otherwise
         if (target == target.getRootProject()) {
+            target.getPlugins().apply(ChecksumPlugin.class);
             target.getPlugins().apply(NexusPublishPlugin.class);
             target.getPlugins().apply(OpenApiMergerGradlePlugin.class);
+            target.getPlugins().apply(ModuleNamesPlugin.class);
+            target.getPlugins().apply(DependencyAnalysisPlugin.class);
         }
     }
 

--- a/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/EdcBuildPlugin.java
@@ -35,13 +35,7 @@ import static org.eclipse.dataspaceconnector.plugins.edcbuild.conventions.Conven
 import static org.eclipse.dataspaceconnector.plugins.edcbuild.conventions.Conventions.tests;
 
 /**
- * Adds (opinionated) conventions (=configuration) for various plugins. Specifically:
- * <ul>
- *     <li>{@link org.gradle.api.plugins.quality.CheckstylePlugin}: <ul>
- *         <li>{@code toolVersion=10}</li>
- *         <li>{@code maxErrors=0}</li>
- *     </ul></li>
- * </ul>
+ * Adds (opinionated) conventions (=configuration) for various plugins.
  */
 public class EdcBuildPlugin implements Plugin<Project> {
     @Override

--- a/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/conventions/JavaConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/conventions/JavaConvention.java
@@ -40,6 +40,12 @@ class JavaConvention implements EdcConvention {
             // making sure the code does not use any APIs from a more recent version.
             // Ref: https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation
             target.getTasks().withType(JavaCompile.class, compileTask -> compileTask.getOptions().getRelease().set(javaVersion.get().asInt()));
+
+            target.getTasks().configureEach(t -> {
+                var javaCompile = (JavaCompile) t;
+                javaCompile.getOptions().setFork(true);
+                javaCompile.getOptions().setIncremental(true);
+            });
         }
 
 

--- a/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/conventions/TestConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/dataspaceconnector/plugins/edcbuild/conventions/TestConvention.java
@@ -48,6 +48,7 @@ class TestConvention implements EdcConvention {
         target.getTasks().withType(Test.class, testTask -> {
             determineJunitPlatform(testTask);
             configureLogging(target.hasProperty("verboseTest"), testTask);
+            testTask.setForkEvery(100L);
         });
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Aims at speeding the Gradle build by applying some simple principles:
- apply plugins only when necessary (root project vs every project)
- set recommended default config options

## Why it does that

Speed up Gradle build

## Further notes

I followed mostly [this guide](https://docs.gradle.org/current/userguide/performance.html).

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
