### PR TITLE
fix(doc): add NOTICE.md file to JAR

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,222 @@
+# Notices for Eclipse Dataspace Connector
+
+This content is produced and maintained by the Eclipse Dash, Tools for
+Committers project.
+
+* Project home: https://projects.eclipse.org/projects/technology.dataspaceconnector
+
+## Trademarks
+
+Eclipse Dataspace Connector and the Eclipse Dataspace Connector logo are trademarks of the Eclipse Foundation.
+Eclipse and the Eclipse Logo are registered trademarks of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of
+content, please consult the listed source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0 which
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+
+## Source Code
+
+The project maintains the following source code repository:
+
+* https://github.com/eclipse-dataspaceconnector/GradlePlugins
+
+## Third-party Content (Overarching All Modules)
+
+FindBugs-jsr305
+
+* Project: http://findbugs.sourceforge.net/
+* Source: scm:git:https://code.google.com/p/jsr-305/
+* Maven Artifact: com.google.code.findbugs/jsr305/3.0.2
+* License: Apache-2.0
+
+error-prone annotations
+
+* Maven Artifact: com.google.errorprone/error_prone_annotations/2.7.1
+* License: Apache-2.0
+
+Guava InternalFutureFailureAccess and InternalFutures
+
+* Maven Artifact: com.google.guava/failureaccess/1.0.1
+* License: Apache-2.0
+
+Guava: Google Core Libraries for Java
+
+* Project: https://github.com/google/guava
+* Maven Artifact: com.google.guava/guava/31.0.1-jre
+* License: Apache-2.0
+
+Guava ListenableFuture only
+
+* Maven Artifact: com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
+* License: LicenseRef-NONE
+
+J2ObjC Annotations
+
+* Project: https://github.com/google/j2objc/
+* Maven Artifact: com.google.j2objc/j2objc-annotations/1.3
+* License: Apache-2.0
+
+checkstyle
+
+* Project: https://checkstyle.org/
+* Source: scm:git:git@github.com:checkstyle/checkstyle.git
+* Maven Artifact: com.puppycrawl.tools/checkstyle/10.0
+* License: LGPL-2.1+
+
+Apache Commons BeanUtils
+
+* Project: https://commons.apache.org/proper/commons-beanutils/
+* Source: scm:svn:http://svn.apache.org/repos/asf/commons/proper/beanutils/tags/BEANUTILS_1_9_3_RC3
+* Maven Artifact: commons-beanutils/commons-beanutils/1.9.4
+* License: Apache-2.0
+
+Apache Commons Collections
+
+* Project: http://commons.apache.org/collections/
+* Source: scm:svn:http://svn.apache.org/repos/asf/commons/proper/collections/trunk
+* Maven Artifact: commons-collections/commons-collections/3.2.2
+* License: Apache-2.0
+
+picocli
+
+* Project: http://picocli.info
+* Source: scm:git:https://github.com/remkop/picocli.git
+* Maven Artifact: info.picocli/picocli/4.6.3
+* License: Apache-2.0
+
+Byte Buddy agent
+
+* Maven Artifact: net.bytebuddy/byte-buddy-agent/1.12.4
+* License: Apache-2.0
+
+Byte Buddy (without dependencies)
+
+* Maven Artifact: net.bytebuddy/byte-buddy/1.12.10
+* License: Apache-2.0
+
+Byte Buddy (without dependencies)
+
+* Maven Artifact: net.bytebuddy/byte-buddy/1.12.4
+* License: Apache-2.0
+
+Saxon-HE
+
+* Project: http://www.saxonica.com/
+* Source: scm:svn:https://dev.saxonica.com/repos/archive/opensource/
+* Maven Artifact: net.sf.saxon/Saxon-HE/10.6
+* License: NOASSERTION
+
+ANTLR 4 Runtime
+
+* Maven Artifact: org.antlr/antlr4-runtime/4.9.3
+* License: BSD-3-Clause
+
+org.apiguardian:apiguardian-api
+
+* Project: https://github.com/apiguardian-team/apiguardian
+* Source: scm:git:git://github.com/apiguardian-team/apiguardian.git
+* Maven Artifact: org.apiguardian/apiguardian-api/1.1.2
+* License: Apache-2.0
+
+AssertJ fluent assertions
+
+* Project: ${project.parent.url}#${project.artifactId}
+* Source: scm:git:https://github.com/assertj/assertj-core.git
+* Maven Artifact: org.assertj/assertj-core/3.23.1
+* License: Apache-2.0
+
+Checker Qual
+
+* Project: https://checkerframework.org
+* Source: scm:git:git://github.com/typetools/checker-framework.git
+* Maven Artifact: org.checkerframework/checker-qual/3.12.0
+* License: MIT
+
+Javassist
+
+* Project: http://www.javassist.org/
+* Source: scm:git:git@github.com:jboss-javassist/javassist.git
+* Maven Artifact: org.javassist/javassist/3.28.0-GA
+* License: Apache-2.0
+
+JUnit Jupiter API
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit.jupiter/junit-jupiter-api/5.9.0
+* License: EPL-2.0
+
+JUnit Jupiter Engine
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit.jupiter/junit-jupiter-engine/5.9.0
+* License: EPL-2.0
+
+JUnit Jupiter Params
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit.jupiter/junit-jupiter-params/5.9.0
+* License: EPL-2.0
+
+JUnit Platform Commons
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit.platform/junit-platform-commons/1.9.0
+* License: EPL-2.0
+
+JUnit Platform Engine API
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit.platform/junit-platform-engine/1.9.0
+* License: EPL-2.0
+
+JUnit 5 (Bill of Materials)
+
+* Project: https://junit.org/junit5/
+* Source: scm:git:git://github.com/junit-team/junit5.git
+* Maven Artifact: org.junit/junit-bom/5.9.0
+* License:
+
+mockito-core
+
+* Project: https://github.com/mockito/mockito
+* Maven Artifact: org.mockito/mockito-core/4.2.0
+* License: MIT
+
+Objenesis
+
+* Maven Artifact: org.objenesis/objenesis/3.2
+* License: Apache-2.0
+
+org.opentest4j:opentest4j
+
+* Project: https://github.com/ota4j-team/opentest4j
+* Source: scm:git:git://github.com/ota4j-team/opentest4j.git
+* Maven Artifact: org.opentest4j/opentest4j/1.2.0
+* License: Apache-2.0
+
+Reflections
+
+* Project: http://github.com/ronmamo/reflections
+* Source: scm:git:git://github.com/ronmamo/reflections.git
+* Maven Artifact: org.reflections/reflections/0.10.2
+* License: Apache-2.0
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import,
+possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of
+encryption software, to see if this is permitted.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,12 @@ allprojects {
         }
     }
 
+    tasks.withType<Jar> {
+        metaInf {
+            from("${rootProject.projectDir.path}/NOTICE.md")
+            from("${rootProject.projectDir.path}/LICENSE")
+        }
+    }
 }
 
 repositories {

--- a/docs/legal/generateThirdPartyReport.sh
+++ b/docs/legal/generateThirdPartyReport.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Usage:
+#   generateThirdPartyReport.sh /path/inputFilename
+#
+# Prerequisites:
+# The Eclipse Dash Licenses tool was executed and resulted in an file (e.g., NOTICES)
+# listing all dependencies of the project.
+# To process the dependencies of a specific module, execute the following command:
+#   gradle dependencies | grep -Poh "(?<=\s)[\w\.-]+:[\w\.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar - -summary NOTICES
+#
+# Comments:
+# Gradle doesn't support listing all dependencies of a multi-module project out of the box.
+# The following custom task can be used to achieve this:
+#   subprojects {
+#     tasks.register<DependencyReportTask>("allDependencies"){}
+#   }
+#
+
+input="$1"
+output="./Third-Party-Content.md"
+
+touch "$output"
+echo -n "" > "$output"
+echo "## Third Party Content" >> "$output"
+
+while IFS= read -r line
+do
+  #Results are separated by comma
+  IFS=', ' read -r -a row <<< "$line"
+  dependency="${row[0]}"
+
+  #Dependencies which could not be resolved are marked as invalid
+  if  [[ $dependency == maven/mavencentral/* ]];
+  then
+      length=${#dependency}
+      mavenPath=${dependency:19:length}
+
+      IFS='/ ' read -r -a hierarchy <<< "$mavenPath"
+
+      groupId=${hierarchy[0]}
+      #Periods must be replaced with slashes to be used later in the context of an URL
+      groupIdUrl=${groupId//./$'/'}
+      artifactId=${hierarchy[1]}
+      version=${hierarchy[2]}
+
+      path="$groupIdUrl/$artifactId/$version/$artifactId-$version.pom"
+
+      #Example URL: https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.pom
+      targetUrl="https://repo1.maven.org/maven2/$path"
+
+      pomFile=$(curl $targetUrl)
+
+      projectName=$(xmllint --xpath "/*[local-name() = 'project']/*[local-name() = 'name']/text()" - <<< $pomFile)
+      projectUrl=$(xmllint --xpath "/*[local-name() = 'project']/*[local-name() = 'url']/text()" - <<< $pomFile)
+      scmUrl=$(xmllint --xpath "/*[local-name() = 'project']/*[local-name() = 'scm']/*[local-name() = 'connection']/text()" - <<< $pomFile)
+
+      if  [[ ! -z "$projectName" ]];
+        then
+          echo "$projectName" >> "$output"
+
+          if  [[ ! -z "$projectUrl" ]];
+            then
+              echo "* Project: $projectUrl" >> "$output"
+          fi
+
+          if  [[ ! -z "$scmUrl" ]];
+            then
+                echo "* Source: $scmUrl" >> "$output"
+          fi
+
+          echo "* Maven Artifact: $mavenPath" >> "$output"
+          echo "* License: ${row[1]}" >> "$output"
+          echo "" >> "$output"
+      fi
+  fi
+
+done < "$input"


### PR DESCRIPTION
## What this PR changes/adds

Adds a `NOTICE.md` and `LICENSE` file to the `META-INF` folder of all the jar archives that this project produces.

## Why it does that

Compliance

## Further notes

- The `LICENSE` was copied verbatim from the EDC project
- The `NOTICE.md` file was in parts also copied, only the third-party section was regenerated using the included shell script
- the `generateThirdPartyReport.sh` was copied verbatim from EDC


## Linked Issue(s)

Closes #29 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
