### PR TITLE
feat(build): read default versions from version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,8 @@ awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" 
 bouncyCastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncyCastle" }
 bouncyCastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncyCastle" }
 cloudEvents = { module = "io.cloudevents:cloudevents-http-basic", version.ref = "cloudEvents" }
-failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
+failsafe-core = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
+failsafe-okhttp = { module = "dev.failsafe:failsafe-okhttp", version.ref = "failsafe" }
 gatling = { module = "io.gatling.highcharts:gatling-charts-highcharts", version.ref = "gatling" }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "httpMockServer" }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -15,7 +15,10 @@
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
 import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.internal.catalog.AbstractExternalDependencyFactory;
+import org.gradle.api.internal.catalog.DefaultVersionCatalog;
 import org.gradle.api.plugins.JavaPlugin;
 
 import static java.lang.String.format;
@@ -32,15 +35,18 @@ class DefaultDependencyConvention implements EdcConvention {
     @Override
     public void apply(Project target) {
         target.getPluginManager().withPlugin("java-library", plugin -> {
+
+
             var ext = requireExtension(target, BuildExtension.class).getVersions();
+            var catalogReader = new CatalogReader(target, ext.getCatalogName());
             var group = EDC_GROUP_ID;
             target.setGroup(group);
             target.setVersion(ext.getProjectVersion().getOrElse("0.0.1-SNAPSHOT"));
 
             // classpath dependencies
             var d = target.getDependencies();
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", ext.getJetbrainsAnnotation().getOrElse("15.0")));
-            var jacksonVersion = ext.getJackson().getOrElse("2.14.0-rc2");
+            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", ext.getJetbrainsAnnotation().getOrElse(catalogReader.versionFor("jetbrainsAnnotation"))));
+            var jacksonVersion = ext.getJackson().getOrElse(catalogReader.versionFor("jackson"));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-core:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-annotations:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-databind:%s", jacksonVersion));
@@ -48,12 +54,41 @@ class DefaultDependencyConvention implements EdcConvention {
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("%s:runtime-metamodel:%s", group, ext.getMetaModel().getOrElse("0.0.1-SNAPSHOT")));
 
             //test classpath dependencies
-            var jupiterVersion = ext.getJupiter().getOrElse("5.8.2");
+            var jupiterVersion = ext.getJupiter().getOrElse(catalogReader.versionFor("jupiter"));
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-api:%s", jupiterVersion));
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-params:%s", jupiterVersion));
             d.add(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-engine:%s", jupiterVersion));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse("4.2.0")));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse("3.22.0")));
+            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse(catalogReader.versionFor("mockito"))));
+            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj"))));
         });
+    }
+
+
+    private static class CatalogReader {
+        private static final String FIELDNAME_CONFIG = "config";
+        private final Project target;
+        private final String catalogName;
+
+        CatalogReader(Project target, String catalogName) {
+            this.target = target;
+            this.catalogName = catalogName;
+        }
+
+        String versionFor(String versionRef) {
+            var factory = target.getExtensions().findByName(catalogName);
+            if (factory == null) {
+                target.getLogger().warn("No VersionCatalog with name {} found. Please either override the version for {} in your build script, or instantiate the version catalog in your client project.", versionRef, catalogName);
+                return null;
+            }
+            try {
+                var field = AbstractExternalDependencyFactory.class.getDeclaredField(FIELDNAME_CONFIG);
+                field.setAccessible(true);
+                var catalog = (DefaultVersionCatalog) field.get(factory);
+                var versionModel = catalog.getVersion(versionRef);
+                return versionModel.getVersion().getRequiredVersion();
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                throw new GradleException("error introspecting catalog", e);
+            }
+        }
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -45,8 +45,8 @@ class DefaultDependencyConvention implements EdcConvention {
 
             // classpath dependencies
             var d = target.getDependencies();
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", ext.getJetbrainsAnnotation().getOrElse(catalogReader.versionFor("jetbrainsAnnotation"))));
-            var jacksonVersion = ext.getJackson().getOrElse(catalogReader.versionFor("jackson"));
+            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", ext.getJetbrainsAnnotation().getOrElse(catalogReader.versionFor("jetbrainsAnnotation", "15.0"))));
+            var jacksonVersion = ext.getJackson().getOrElse(catalogReader.versionFor("jackson", "2.14.0-rc2"));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-core:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-annotations:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-databind:%s", jacksonVersion));
@@ -54,12 +54,12 @@ class DefaultDependencyConvention implements EdcConvention {
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("%s:runtime-metamodel:%s", group, ext.getMetaModel().getOrElse("0.0.1-SNAPSHOT")));
 
             //test classpath dependencies
-            var jupiterVersion = ext.getJupiter().getOrElse(catalogReader.versionFor("jupiter"));
+            var jupiterVersion = ext.getJupiter().getOrElse(catalogReader.versionFor("jupiter", "5.8.2"));
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-api:%s", jupiterVersion));
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-params:%s", jupiterVersion));
             d.add(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-engine:%s", jupiterVersion));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse(catalogReader.versionFor("mockito"))));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj"))));
+            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse(catalogReader.versionFor("mockito", "4.2.0"))));
+            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj", "3.22.0"))));
         });
     }
 
@@ -74,11 +74,11 @@ class DefaultDependencyConvention implements EdcConvention {
             this.catalogName = catalogName;
         }
 
-        String versionFor(String versionRef) {
+        String versionFor(String versionRef, String defaultValue) {
             var factory = target.getExtensions().findByName(catalogName);
             if (factory == null) {
                 target.getLogger().warn("No VersionCatalog with name {} found. Please either override the version for {} in your build script, or instantiate the version catalog in your client project.", versionRef, catalogName);
-                return null;
+                return defaultValue;
             }
             try {
                 var field = AbstractExternalDependencyFactory.class.getDeclaredField(FIELDNAME_CONFIG);

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/VersionsExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/VersionsExtension.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.plugins.edcbuild.extensions;
 import org.gradle.api.provider.Property;
 
 public abstract class VersionsExtension {
+    private String catalogName = "libs";
+
     public abstract Property<String> getProjectVersion();
 
     public abstract Property<String> getJetbrainsAnnotation();
@@ -30,5 +32,13 @@ public abstract class VersionsExtension {
     public abstract Property<String> getMockito();
 
     public abstract Property<String> getAssertJ();
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
+    }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Reads the default versions, that the build plugin provides, from the version catalog, if one exists.

## Why it does that

further centralize version management

## Further notes

- if no version catalog is found, a fallback value is used.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
