### PR TITLE
feat(build): add apiGroup to config

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConvention.java
@@ -21,6 +21,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.hidetake.gradle.swagger.generator.SwaggerGeneratorPlugin;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
@@ -30,6 +31,9 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.SwaggerConvention.def
  * Congfigures the Swagger Generator to create openapi yaml file per project
  */
 class SwaggerGeneratorConvention implements EdcConvention {
+
+    private static final String DEFAULT_API_GROUP = "";
+
     @Override
     public void apply(Project target) {
         // apply root script plugin
@@ -46,10 +50,15 @@ class SwaggerGeneratorConvention implements EdcConvention {
 
             var javaExt = requireExtension(target, JavaPluginExtension.class);
             var swaggerExt = requireExtension(target, BuildExtension.class).getSwagger();
-            var outputPath = defaultOutputDirectory(target);
+            var fallbackOutputDir = defaultOutputDirectory(target);
 
             var outputFileName = swaggerExt.getOutputFilename().getOrElse(target.getName());
-            var outputDir = swaggerExt.getOutputDirectory().getOrElse(outputPath.toFile());
+
+            var apiGroup = swaggerExt.getApiGroup().getOrElse(DEFAULT_API_GROUP);
+            var outputDir = Path.of(swaggerExt.getOutputDirectory().getOrElse(fallbackOutputDir.toFile()).toURI())
+                    .resolve(apiGroup)
+                    .toFile();
+
             var resourcePkgs = swaggerExt.getResourcePackages(); // already provides the default
 
             target.getTasks().withType(ResolveTask.class, task -> {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/SwaggerGeneratorExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/SwaggerGeneratorExtension.java
@@ -77,4 +77,7 @@ public abstract class SwaggerGeneratorExtension {
     public void setMergedFileExtension(String mergedFileExtension) {
         this.mergedFileExtension = mergedFileExtension;
     }
+
+    public abstract Property<String> getApiGroup();
+
 }

--- a/plugins/edc-build/src/test/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConventionTest.java
+++ b/plugins/edc-build/src/test/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConventionTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.conventions;
+
+import io.swagger.v3.plugins.gradle.tasks.ResolveTask;
+import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hidetake.gradle.swagger.generator.SwaggerGeneratorPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SwaggerGeneratorConventionTest {
+
+
+    private static final String PROJECT_NAME = "testproject";
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        project = ProjectBuilder.builder().withName(PROJECT_NAME).build();
+        project.getPluginManager().apply("io.swagger.core.v3.swagger-gradle-plugin");
+        project.getPluginManager().apply(JavaPlugin.class);
+        project.getExtensions().create("edcBuild", BuildExtension.class, project.getObjects());
+    }
+
+    @Test
+    void apply_whenApiGroupNotSpecified_shouldUseDefault() {
+        var convention = new SwaggerGeneratorConvention();
+        convention.apply(project);
+
+        assertThat(project.getPlugins().findPlugin(SwaggerGeneratorPlugin.class)).isNotNull();
+
+        var resolveTask = (ResolveTask) project.getTasks().getByName("resolve");
+
+        assertThat(resolveTask.getOutputDir().getPath()).endsWith("/resources/openapi/yaml");
+        assertThat(resolveTask.getOutputFileName()).isEqualTo(PROJECT_NAME);
+        assertThat(resolveTask.getOutputFormat()).isEqualTo(ResolveTask.Format.YAML);
+    }
+
+    @Test
+    void apply_whenApiGroupSpecified_shouldAppend() {
+        var swagger = ConventionFunctions.requireExtension(project, BuildExtension.class).getSwagger();
+        swagger.getApiGroup().set("test-api");
+        var convention = new SwaggerGeneratorConvention();
+        convention.apply(project);
+
+        assertThat(project.getPlugins().findPlugin(SwaggerGeneratorPlugin.class)).isNotNull();
+
+        var resolveTask = (ResolveTask) project.getTasks().getByName("resolve");
+
+        assertThat(resolveTask.getOutputDir().getPath()).endsWith("/resources/openapi/yaml/test-api");
+        assertThat(resolveTask.getOutputFileName()).isEqualTo(PROJECT_NAME);
+        assertThat(resolveTask.getOutputFormat()).isEqualTo(ResolveTask.Format.YAML);
+    }
+
+    @Test
+    void apply_whenOutputDirSet_shouldAppend() {
+        var swagger = ConventionFunctions.requireExtension(project, BuildExtension.class).getSwagger();
+        swagger.getApiGroup().set("test-api");
+        swagger.getOutputDirectory().set(new File("some/funny/path"));
+        var convention = new SwaggerGeneratorConvention();
+        convention.apply(project);
+
+        assertThat(project.getPlugins().findPlugin(SwaggerGeneratorPlugin.class)).isNotNull();
+
+        var resolveTask = (ResolveTask) project.getTasks().getByName("resolve");
+
+        assertThat(resolveTask.getOutputDir().getPath()).endsWith("/some/funny/path/test-api");
+        assertThat(resolveTask.getOutputFileName()).isEqualTo(PROJECT_NAME);
+        assertThat(resolveTask.getOutputFormat()).isEqualTo(ResolveTask.Format.YAML);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

adds the `apiGroup` to the `SwaggerGeneratorExtension` and appends it to the chosen `outputDir` for openapi generation.

## Why it does that

To be able to group together several API modules.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #40 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
