### PR TITLE
fix: apply nexus convention during the config phase

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
@@ -47,6 +47,8 @@ public class EdcBuildPlugin implements Plugin<Project> {
         // apply all plugins
         target.getPlugins().apply(EdcBuildBasePlugin.class);
 
+        //this one must run in the configuration phase
+        nexusPublishing().apply(target);
 
         // configuration values are only guaranteed to be set after the project has been evaluated
         // https://docs.gradle.org/current/userguide/build_lifecycle.html
@@ -68,7 +70,7 @@ public class EdcBuildPlugin implements Plugin<Project> {
                     dependencyAnalysis(),
                     tests(),
                     jar(),
-                    nexusPublishing(),
+
                     swagger()
             ).forEach(c -> c.apply(project));
         });

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -77,7 +77,7 @@ class DefaultDependencyConvention implements EdcConvention {
         String versionFor(String versionRef, String defaultValue) {
             var factory = target.getExtensions().findByName(catalogName);
             if (factory == null) {
-                target.getLogger().warn("No VersionCatalog with name {} found. Please either override the version for {} in your build script, or instantiate the version catalog in your client project.", versionRef, catalogName);
+                target.getLogger().debug("No VersionCatalog with name {} found. Please either override the version for {} in your build script, or instantiate the version catalog in your client project.", catalogName, versionRef);
                 return defaultValue;
             }
             try {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
@@ -17,15 +17,15 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 import io.github.gradlenexus.publishplugin.NexusPublishExtension;
 import org.gradle.api.Project;
 
-import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.sonatypeRepo;
 
 class NexusPublishingConvention implements EdcConvention {
     @Override
     public void apply(Project target) {
         if (target == target.getRootProject()) {
-            var pubExt = requireExtension(target, NexusPublishExtension.class);
-            pubExt.repositories(sonatypeRepo());
+            target.getExtensions().configure(NexusPublishExtension.class, nexusPublishExtension -> {
+                nexusPublishExtension.repositories(sonatypeRepo());
+            });
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes a build problem, where the `publishToSonatype` Gradle task was not found, because the nexus publishing convention was applied too late.


## Why it does that

fix the build.
