### PR TITLE
feat: create custom merger task

### DIFF
--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":plugins:autodoc:autodoc-plugin"))
     implementation(project(":plugins:test-summary"))
     implementation(project(":plugins:module-names"))
+    implementation(project(":plugins:openapi-merger"))
 
     implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.13.1")
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildBasePlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildBasePlugin.java
@@ -15,10 +15,10 @@
 package org.eclipse.edc.plugins.edcbuild;
 
 import com.autonomousapps.DependencyAnalysisPlugin;
-import com.rameshkp.openapi.merger.gradle.plugin.OpenApiMergerGradlePlugin;
 import io.github.gradlenexus.publishplugin.NexusPublishPlugin;
 import org.eclipse.edc.plugins.autodoc.AutodocPlugin;
 import org.eclipse.edc.plugins.modulenames.ModuleNamesPlugin;
+import org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin;
 import org.eclipse.edc.plugins.testsummary.TestSummaryPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -49,7 +49,7 @@ public class EdcBuildBasePlugin implements Plugin<Project> {
         if (target == target.getRootProject()) {
             target.getPlugins().apply(ChecksumPlugin.class);
             target.getPlugins().apply(NexusPublishPlugin.class);
-            target.getPlugins().apply(OpenApiMergerGradlePlugin.class);
+            target.getPlugins().apply(OpenApiMergerPlugin.class);
             target.getPlugins().apply(ModuleNamesPlugin.class);
             target.getPlugins().apply(DependencyAnalysisPlugin.class);
         }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
@@ -70,10 +70,10 @@ public class EdcBuildPlugin implements Plugin<Project> {
                     dependencyAnalysis(),
                     tests(),
                     jar(),
-
                     swagger()
             ).forEach(c -> c.apply(project));
         });
+
 
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/ConventionFunctions.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/ConventionFunctions.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 import static java.util.Optional.ofNullable;
 
-class ConventionFunctions {
+public class ConventionFunctions {
 
     /**
      * Supplies a generic {@link GradleException} with the given message.
@@ -33,11 +33,11 @@ class ConventionFunctions {
     /**
      * Supplies a {@link GradleException} that has a specific message indicating that a particular extension is missing.
      */
-    public static Supplier<GradleException> extensionException(Class<?> extensionClass) {
+    static Supplier<GradleException> extensionException(Class<?> extensionClass) {
         return gradleException(extensionClass.getSimpleName() + " expected but was null");
     }
 
-    static <A> A requireExtension(Project target, Class<A> extensionClass) {
+    public static <A> A requireExtension(Project target, Class<A> extensionClass) {
         return ofNullable(target.getExtensions().findByType(extensionClass))
                 .orElseThrow(extensionException(extensionClass));
     }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerGeneratorConvention.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 
 import io.swagger.v3.plugins.gradle.tasks.ResolveTask;
 import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
+import org.eclipse.edc.plugins.edcbuild.tasks.PrintApiGroupTask;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -42,6 +43,9 @@ class SwaggerGeneratorConvention implements EdcConvention {
         }
 
         target.getPluginManager().withPlugin("io.swagger.core.v3.swagger-gradle-plugin", appliedPlugin -> {
+
+            target.getTasks().register("apiGroups", PrintApiGroupTask.class);
+
             target.getDependencies().add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
                     "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.2");
             target.getDependencies().add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/PrintApiGroupTask.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/PrintApiGroupTask.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.tasks;
+
+import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
+
+
+public class PrintApiGroupTask extends DefaultTask {
+
+    @TaskAction
+    public void printApiGroup() {
+        var buildExt = requireExtension(getProject(), BuildExtension.class);
+        getProject().getLogger().lifecycle("API Group: {}", buildExt.getSwagger().getApiGroup().getOrElse(""));
+    }
+}

--- a/plugins/openapi-merger/README.md
+++ b/plugins/openapi-merger/README.md
@@ -1,0 +1,1 @@
+This module contains a gradle plugin that allows to merge partial OpenAPI spec files into one file.

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    `java-gradle-plugin`
+    id("org.gradle.crypto.checksum") version "1.4.0"
+}
+
+val jupiterVersion: String by project
+val assertj: String by project
+val groupId: String by project
+
+dependencies {
+    // contains the actual merger task
+    implementation("com.rameshkp:openapi-merger-gradle-plugin:1.0.4")
+    // needed for the OpenApiDataInvalidException:
+    implementation("com.rameshkp:openapi-merger-app:1.0.4")
+}
+
+gradlePlugin {
+    // Define the plugin
+    plugins {
+        create("openapi-merger") {
+            displayName = "openapi-merger"
+            description =
+                "Plugin to several OpenAPI spec files into one"
+            id = "${groupId}.openapi-merger"
+            implementationClass = "org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin"
+        }
+    }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "openapi", "merge", "documentation")
+}

--- a/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/OpenApiMergerPlugin.java
+++ b/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/OpenApiMergerPlugin.java
@@ -31,7 +31,6 @@ public class OpenApiMergerPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
 
-        // can only be used in the root project
         if (project == project.getRootProject()) {
             project.getPlugins().apply(OpenApiMergerGradlePlugin.class);
             project.getTasks().register(MergeApiSpecByPathTask.NAME, MergeApiSpecByPathTask.class);

--- a/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/OpenApiMergerPlugin.java
+++ b/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/OpenApiMergerPlugin.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.openapimerger;
+
+import com.rameshkp.openapi.merger.gradle.plugin.OpenApiMergerGradlePlugin;
+import org.eclipse.edc.plugins.openapimerger.tasks.MergeApiSpecByPathTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Custom grade plugin to avoid module name duplications.
+ * Checks between modules with a gradle build file that their names are unique in the whole project.
+ * `samples` and `system-tests` modules are excluded.
+ * <p>
+ * Ref: <a href="https://github.com/gradle/gradle/issues/847">Github Issue</a>
+ */
+public class OpenApiMergerPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+
+        // can only be used in the root project
+        if (project == project.getRootProject()) {
+            project.getPlugins().apply(OpenApiMergerGradlePlugin.class);
+            project.getTasks().register(MergeApiSpecByPathTask.NAME, MergeApiSpecByPathTask.class);
+        }
+    }
+
+}

--- a/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/tasks/MergeApiSpecByPathTask.java
+++ b/plugins/openapi-merger/src/main/java/org/eclipse/edc/plugins/openapimerger/tasks/MergeApiSpecByPathTask.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.openapimerger.tasks;
+
+import com.rameshkp.openapi.merger.gradle.task.OpenApiMergerTask;
+import org.gradle.api.tasks.options.Option;
+
+import java.io.File;
+
+/**
+ * Customization of the {@link OpenApiMergerTask}, which allows to pass in the input and output directories via command line.
+ */
+public class MergeApiSpecByPathTask extends OpenApiMergerTask {
+
+    public static final String NAME = "mergeApiSpec";
+
+    @Option(option = "output", description = "Output directory where the merged spec file is stores. Optional.")
+    public void setOutputDir(String outputDirectory) {
+        // inject the command line arg into the merger task's config
+        getOutputFileProperty().set(new File(outputDirectory));
+    }
+
+    @Option(option = "input", description = "Input directory where to look for partial specs. Required")
+    public void setInputDir(String inputDir) {
+        // inject the command line arg into the merger task's config
+        getInputDirectory().set(new File(inputDir));
+    }
+}
+

--- a/plugins/openapi-merger/src/test/java/org/eclipse/edc/plugins/modulenames/OpenApiMergerPluginTest.java
+++ b/plugins/openapi-merger/src/test/java/org/eclipse/edc/plugins/modulenames/OpenApiMergerPluginTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.modulenames;
+
+import org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiMergerPluginTest {
+
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        // Create a test project and apply the plugin
+        project = ProjectBuilder.builder().build();
+
+        project.getPlugins().apply(OpenApiMergerPlugin.class);
+    }
+
+    @Test
+    void verify_hasMergerTask() {
+        assertThat(project.getTasks().findByName("mergeApiSpec")).isNotNull();
+    }
+
+
+}

--- a/plugins/openapi-merger/src/test/java/org/eclipse/edc/plugins/modulenames/OpenApiMergerPluginTest.java
+++ b/plugins/openapi-merger/src/test/java/org/eclipse/edc/plugins/modulenames/OpenApiMergerPluginTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.plugins.modulenames;
 
 import org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin;
+import org.eclipse.edc.plugins.openapimerger.tasks.MergeApiSpecByPathTask;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,16 +29,23 @@ class OpenApiMergerPluginTest {
 
     @BeforeEach
     void setUp() {
-        // Create a test project and apply the plugin
         project = ProjectBuilder.builder().build();
-
         project.getPlugins().apply(OpenApiMergerPlugin.class);
     }
 
     @Test
     void verify_hasMergerTask() {
-        assertThat(project.getTasks().findByName("mergeApiSpec")).isNotNull();
+        assertThat(project.getTasks().findByName(MergeApiSpecByPathTask.NAME)).isNotNull();
     }
 
+
+    @Test
+    void verify_pluginIsOnlyAppliedToRootProject() {
+        var subproj = ProjectBuilder.builder().withParent(project).build();
+
+        subproj.getPlugins().apply(OpenApiMergerPlugin.class);
+
+        assertThat(subproj.getTasks().findByName(MergeApiSpecByPathTask.NAME)).isNull();
+    }
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "edcPlugins"
 include("plugins:module-names")
 include("plugins:test-summary")
+include("plugins:openapi-merger")
 include("plugins:edc-build")
 include("plugins:autodoc:autodoc-plugin")
 include("plugins:autodoc:autodoc-processor")


### PR DESCRIPTION
## What this PR changes/adds

Creates a new custom task, that extends the `OpenApiMergerTask`, but gives us the opportunity to supply `input` and `output` directories via command line arguments:

```bash
./gradlew :mergeApiSpec --input=path/to/partial_api_spec --output=./merged.yaml
```

## Why it does that

Allows to dynamically adapt the input directory, where all the partial api specs are. The plain `OpenApiMergerTask` would need to be configured e.g. using a pre-compiled script.

This way we can easily configure a CI job and produce separate api specs.

## Further notes

- I also created another task `apiGroups`, which prints each module's `apiGroup`. It is intended for developer convenience

## Linked Issue(s)

Closes #41 

