### PR TITLE
fix: explicitly exclude annotation processors from dep-analysis

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
@@ -77,7 +77,7 @@ class AutodocDependencyInjector implements DependencyResolutionListener {
     private boolean addDependency(Project project, String dependencyName) {
         var apConfig = project.getConfigurations().findByName(ANNOTATION_PROCESSOR);
         if (apConfig != null) {
-            project.getLogger().debug("autodoc: Add dependency annotationProcessor(\"{}\") to project {}", dependencyName, project.getName());
+            project.getLogger().debug("autodoc: Add dependency {}(\"{}\") to project {}", ANNOTATION_PROCESSOR, dependencyName, project.getName());
             return apConfig.getDependencies().add(project.getDependencies().create(dependencyName));
         }
         return false;

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DependencyAnalysisConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DependencyAnalysisConvention.java
@@ -57,14 +57,16 @@ class DependencyAnalysisConvention implements EdcConvention {
                             "com.fasterxml.jackson.core:jackson-annotations",
                             "com.fasterxml.jackson.core:jackson-databind");
                 });
+                a.onUnusedAnnotationProcessors(i -> i.exclude(
+                        "org.eclipse.edc:autodoc-processor"
+                ));
                 a.onUnusedDependencies(i -> i.exclude(
                         // dependencies declared at the root level for all modules
                         "org.assertj:assertj-core",
                         "org.junit.jupiter:junit-jupiter-api",
                         "org.junit.jupiter:junit-jupiter-params",
                         "org.mockito:mockito-core",
-                        "org.eclipse.edc:runtime-metamodel",
-                        "org.eclipse.edc:autodoc-processor"
+                        "org.eclipse.edc:runtime-metamodel"
                 ));
                 a.onIncorrectConfiguration(i -> i.exclude(
                         // some common dependencies are intentionally exported by core:common:connector-core for simplicity


### PR DESCRIPTION
## What this PR changes/adds

Previously the `autodoc` annotation processor dependency was not excluded from the `dependency-analysis` plugin, which it should be. 
This PR fixes that.

## Why it does that

Avoid wrong dependency analysis warnings.

## Further notes

.

## Linked Issue(s)

.
