### PR TITLE
feat: add defaultValue to `@Setting`

### DIFF
--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
@@ -38,6 +38,7 @@ public @interface Setting {
 
     /**
      * The setting default value. Empty string if no default value is provided
+     *
      * @return the setting's default value
      */
     String defaultValue() default "";

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
@@ -34,6 +35,12 @@ public @interface Setting {
     String value() default "";
 
     String type() default "string";
+
+    /**
+     * The setting default value. Empty string if no default value is provided
+     * @return the setting's default value
+     */
+    String defaultValue() default "";
 
     long min() default Long.MIN_VALUE;
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "edcPlugins"
+rootProject.name = "GradlePlugins"
 include("plugins:module-names")
 include("plugins:test-summary")
 include("plugins:openapi-merger")


### PR DESCRIPTION
## What this PR changes/adds

Add a `defaultValue()` method to `@Setting`

## Why it does that

Improve documentation

## Further notes

- set `rootProject.name` equal to the repository name `GradlePlugins`, for coherency

## Linked Issue(s)

Closes #52

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
