### PR TITLE
fix: Revert "chore: remove @EdcSettng and @EdcSettingContext from the…

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.plugins.autodoc.core.processor.introspection;
 
+import org.eclipse.edc.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -79,7 +80,7 @@ public class ModuleIntrospector {
      *     <li>Are annotated with {@link Provides}</li>
      *     <li>Are annotated with {@link Requires}</li>
      *     <li>Have one or more fields annotated with {@link Inject}</li>
-     *     <li>Have one or more fields annotated with {@link Setting}</li>
+     *     <li>Have one or more fields annotated with {@link EdcSetting}</li>
      *     <li>Have one or more methods annotated with {@link Provider}</li>
      * </ul>
      * <p>
@@ -91,13 +92,14 @@ public class ModuleIntrospector {
      */
     public Set<Element> getExtensionElements(RoundEnvironment environment) {
         var extensionClasses = environment.getElementsAnnotatedWith(Extension.class);
+        var settingsSymbolsDeprecated = environment.getElementsAnnotatedWith(EdcSetting.class);
         var settingsSymbols = environment.getElementsAnnotatedWith(Setting.class);
         var injectSymbols = environment.getElementsAnnotatedWith(Inject.class);
         var providerSymbols = environment.getElementsAnnotatedWith(Provider.class);
         var providesClasses = environment.getElementsAnnotatedWith(Provides.class);
         var requiresClasses = environment.getElementsAnnotatedWith(Requires.class);
 
-        var symbols = settingsSymbols.stream();
+        var symbols = Stream.concat(settingsSymbols.stream(), settingsSymbolsDeprecated.stream());
         symbols = Stream.concat(symbols, injectSymbols.stream());
         symbols = Stream.concat(symbols, providerSymbols.stream());
 

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
@@ -15,15 +15,15 @@
 package org.eclipse.edc.plugins.autodoc.core.processor.testextensions;
 
 import org.eclipse.edc.plugins.autodoc.core.processor.Constants;
+import org.eclipse.edc.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
 @Provides(SomeOtherService.class)
 public class SampleExtensionWithoutAnnotation implements ServiceExtension {
-    @Setting(value = Constants.TEST_SETTING_NAME, required = true)
+    @EdcSetting(value = Constants.TEST_SETTING_NAME, required = true)
     public static final String TEST_SETTING = Constants.TEST_SETTING_KEY;
 
     @Inject

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/EdcSetting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/EdcSetting.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.runtime.metamodel.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes a runtime configuration setting.
+ *
+ * @deprecated Please use {@link Setting}
+ */
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Deprecated
+public @interface EdcSetting {
+
+    /**
+     * The setting description.
+     */
+    String value() default "";
+
+    String type() default "string";
+
+    long min() default Long.MIN_VALUE;
+
+    long max() default Long.MAX_VALUE;
+
+    /**
+     * Returns true if the setting is required.
+     */
+    boolean required() default false;
+
+}

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/EdcSettingContext.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/EdcSettingContext.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.runtime.metamodel.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a context for setting keys.
+ *
+ * @deprecated please use {@link SettingContext}
+ */
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Deprecated
+public @interface EdcSettingContext {
+    String value();
+}


### PR DESCRIPTION

## What this PR changes/adds

This reverts commit f190f7fd0d98cbfde3a1ce3b608090b7835f7864.

## Why it does that

Removing the deprecated `@EdcSetting` annotation would leave EDC's `milestone-7` release uncompileable, because it depends on `runtime-metamodel:0.0.1-SNAPSHOT` and it still contains one reference to `@EdcSetting`.

## Further notes

This needs to be re-reverted after the `milestone-8` release of EDC. Furthermore, we should consider releasing pinned versions of `runtime-metamodel` together with EDC.

## Linked Issue(s)

Closes https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/2231

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
